### PR TITLE
fix - remove .in suffix from rhcd unit files

### DIFF
--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -51,9 +51,9 @@ install -d %{buildroot}%{_presetdir}
 install -m644 %{SOURCE4} -t %{buildroot}%{_presetdir}/
 
 # rhcd
-install -D -m644 %{SOURCE6} %{buildroot}%{_unitdir}/
-install -D -m644 %{SOURCE7} %{buildroot}%{_unitdir}/
-install -D -m644 %{SOURCE8} %{buildroot}%{_unitdir}/
+install -D -m644 rhcd.path %{buildroot}%{_unitdir}/
+install -D -m644 rhcd-stop.path %{buildroot}%{_unitdir}/
+install -D -m644 rhcd-stop.service %{buildroot}%{_unitdir}/
 
 %post
 %systemd_post insights-register.path


### PR DESCRIPTION
rhcd unit files are generated with `.in` suffix, and this PR suppose to fix it:
```
# rpm -ql redhat-cloud-client-configuration-1-1.el9.noarch
/usr/lib/systemd/system-preset/80-insights-register.preset
/usr/lib/systemd/system/insights-register.path
/usr/lib/systemd/system/insights-register.service
/usr/lib/systemd/system/insights-unregister.path
/usr/lib/systemd/system/insights-unregister.service
/usr/lib/systemd/system/rhcd-stop.path.in
/usr/lib/systemd/system/rhcd-stop.service.in
/usr/lib/systemd/system/rhcd.path.in
```