### PR TITLE
Fix - Executable path is not absolute, ignoring: systemctl ...

### DIFF
--- a/insights-register.service.in
+++ b/insights-register.service.in
@@ -25,4 +25,4 @@ TasksMax=300
 BlockIOWeight=100
 ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.memsw.limit_in_bytes"
 ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.soft_limit_in_bytes"
-ExecStopPost=systemctl mask --now insights-register.path
+ExecStopPost=/bin/systemctl mask --now insights-register.path

--- a/insights-unregister.service.in
+++ b/insights-unregister.service.in
@@ -18,6 +18,6 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=@bindir@/insights-client --unregister --force
-ExecStopPost=systemctl unmask --now insights-register.path
-ExecStopPost=systemctl start insights-register.path
+ExecStopPost=/bin/systemctl unmask --now insights-register.path
+ExecStopPost=/bin/systemctl start insights-register.path
 Restart=no

--- a/rhcd-stop.service.in
+++ b/rhcd-stop.service.in
@@ -15,6 +15,6 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 
 [Service]
 Type=simple
-ExecStart=systemctl stop rhcd.service
-ExecStopPost=systemctl unmask --now rhcd.path
-ExecStopPost=systemctl start rhcd.path
+ExecStart=/bin/systemctl stop rhcd.service
+ExecStopPost=/bin/systemctl unmask --now rhcd.path
+ExecStopPost=/bin/systemctl start rhcd.path


### PR DESCRIPTION
on RHEL7 machines, systemd was complaining about not used absolute paths for Exec* directives. e.g.
```
Jun 21 15:11:46 xyz.ec2.internal systemd[1]: [/usr/lib/systemd/system/rhcd-stop.service:18] Executable path is not absolute, ignoring: systemctl stop rhcd.service
Jun 21 15:11:46 xyz.ec2.internal systemd[1]: [/usr/lib/systemd/system/rhcd-stop.service:19] Executable path is not absolute, ignoring: systemctl unmask --now rhcd.path
Jun 21 15:11:46 xyz.ec2.internal systemd[1]: [/usr/lib/systemd/system/rhcd-stop.service:20] Executable path is not absolute, ignoring: systemctl start rhcd.path
Jun 21 15:11:46 xyz.ec2.internal systemd[1]: rhcd-stop.service lacks both ExecStart= and ExecStop= setting. Refusing.
```
This PR suppose to fix this.