### PR TITLE
Add auto-registration when insights-client manually unregister [ESSNTL-3043]

### DIFF
--- a/80-insights-register.preset
+++ b/80-insights-register.preset
@@ -2,3 +2,5 @@ enable insights-register.path
 enable insights-unregister.path
 enable rhcd.path
 enable rhcd-stop.path
+enable insights-unregistered.path
+enable rhcd.service

--- a/80-insights-register.preset
+++ b/80-insights-register.preset
@@ -1,6 +1,3 @@
 enable insights-register.path
 enable insights-unregister.path
-enable rhcd.path
-enable rhcd-stop.path
 enable insights-unregistered.path
-enable rhcd.service

--- a/80-rhcd-register.preset
+++ b/80-rhcd-register.preset
@@ -1,0 +1,2 @@
+enable rhcd.path
+enable rhcd-stop.path

--- a/insights-unregistered.path.in
+++ b/insights-unregistered.path.in
@@ -1,0 +1,18 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-unregistered.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Check if manually Unregistered from Red Hat Insights Client Path Watch
+Documentation=man:insights-client(8)
+
+[Path]
+PathExists=@sysconfdir@/insights-client/.unregistered
+
+[Install]
+WantedBy=multi-user.target

--- a/insights-unregistered.service.in
+++ b/insights-unregistered.service.in
@@ -2,7 +2,7 @@
 #
 # Any changes made to this file will be overwritten during a software update. To
 # override a parameter in this file, create a drop-in file, typically located at
-# /etc/systemd/system/insights-unregister.service.d/override.conf. Put the
+# /etc/systemd/system/insights-unregistered.service.d/override.conf. Put the
 # desired overrides in that file and reload systemd. The next time this service
 # is run (either manually or via a systemd timer), the overridden values will be
 # in effect.
@@ -10,12 +10,13 @@
 # For more information about systemd drop-in files, see systemd.unit(5).
 
 [Unit]
-Description=Automatically Unregister from Red Hat Insights
+Description=Automatically check if manually Unregistered from Red Hat Insights Client
 Documentation=man:insights-client(8)
 After=network-online.target
-ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
+ConditionPathExists=@sysconfdir@/insights-client/.unregistered
 
 [Service]
 Type=simple
-ExecStart=@bindir@/insights-client --unregister --force
+ExecStart=systemctl unmask --now insights-register.path
+ExecStop=systemctl start insights-register.path
 Restart=no

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -10,10 +10,12 @@ Source1: insights-register.service.in
 Source2: insights-unregister.path.in
 Source3: insights-unregister.service.in
 Source4: 80-insights-register.preset
+Source5: insights-unregistered.path.in
+Source6: insights-unregistered.service.in
 %if 0%{?rhel} >= 8
-Source6: rhcd.path.in
-Source7: rhcd-stop.path.in
-Source8: rhcd-stop.service.in
+Source7: rhcd.path.in
+Source8: rhcd-stop.path.in
+Source9: rhcd-stop.service.in
 %endif
 
 BuildArch:      noarch
@@ -40,12 +42,14 @@ sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE0} > insights-register.path
 sed -e 's|@bindir@|%{_bindir}|g' %{SOURCE1} > insights-register.service
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE2} > insights-unregister.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@bindir@|%{_bindir}|g' %{SOURCE3} > insights-unregister.service
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE5} > insights-unregistered.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE6} > insights-unregistered.service
 
 %if 0%{?rhel} >= 8
 # rhcd
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE6} > rhcd.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > rhcd-stop.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > rhcd-stop.service
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > rhcd.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > rhcd-stop.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > rhcd-stop.service
 %endif
 
 %install
@@ -55,6 +59,8 @@ install -m644 insights-register.path    %{buildroot}%{_unitdir}/
 install -m644 insights-register.service %{buildroot}%{_unitdir}/
 install -m644 insights-unregister.path    %{buildroot}%{_unitdir}/
 install -m644 insights-unregister.service %{buildroot}%{_unitdir}/
+install -m644 insights-unregistered.path %{buildroot}%{_unitdir}/
+install -m644 insights-unregistered.service %{buildroot}%{_unitdir}/
 install -d %{buildroot}%{_presetdir}
 install -m644 %{SOURCE4} -t %{buildroot}%{_presetdir}/
 
@@ -69,6 +75,7 @@ install -D -m644 rhcd-stop.service %{buildroot}%{_unitdir}/
 %systemd_post insights-register.path
 %systemd_post insights-unregister.path
 %systemd_post 80-insights-register.preset
+%systemd_post insights-unregistered.path
 
 %if 0%{?rhel} >= 8
 %systemd_post rhcd.path
@@ -107,6 +114,7 @@ if [ $1 -eq 0 ]; then
 fi
 %systemd_preun insights-register.path
 %systemd_preun insights-unregister.path
+%systemd_preun insights-unregistered.path
 
 %if 0%{?rhel} >= 8
 %systemd_preun rhcd.path
@@ -116,11 +124,13 @@ fi
 %postun
 %systemd_postun insights-register.path
 %systemd_postun insights-unregister.path
+%systemd_postun insights-unregistered.path
 
 %if 0%{?rhel} >= 8
 %systemd_postun rhcd.path
 %systemd_postun rhcd-stop.path
 %endif
+
 
 if [ $1 -eq 0 ]; then
     if [ -f /etc/rhsm/rhsm.conf.cloud_save ]; then

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -16,6 +16,7 @@ Source6: insights-unregistered.service.in
 Source7: rhcd.path.in
 Source8: rhcd-stop.path.in
 Source9: rhcd-stop.service.in
+Source10: 80-rhcd-register.preset
 %endif
 
 BuildArch:      noarch
@@ -69,17 +70,20 @@ install -m644 %{SOURCE4} -t %{buildroot}%{_presetdir}/
 install -D -m644 rhcd.path %{buildroot}%{_unitdir}/
 install -D -m644 rhcd-stop.path %{buildroot}%{_unitdir}/
 install -D -m644 rhcd-stop.service %{buildroot}%{_unitdir}/
+install -m644 %{SOURCE10} -t %{buildroot}%{_presetdir}/
 %endif
 
 %post
+# insights-client
 %systemd_post insights-register.path
 %systemd_post insights-unregister.path
 %systemd_post 80-insights-register.preset
 %systemd_post insights-unregistered.path
-
+#rhcd
 %if 0%{?rhel} >= 8
 %systemd_post rhcd.path
 %systemd_post rhcd-stop.path
+%systemd_post 80-rhcd-register.preset
 %endif
 
 # Make sure that rhsmcertd.service is enabled and running


### PR DESCRIPTION
At this moment when `insights-client` is unregister manually, auto-registration would not try to register the client again.  

This PR enables the auto-registration if `insights-client --unregister` command is run manually by the user.

1. There is a new service `insights-unregistered` and path that will check if `insights-client` is unregistered and when that happens it will call `insights-register.path`
2. `insights-unregister`  will be triggered just when `subscription-manager unregister` and it will unregisters  the `insights-client`

Split preset file in two different files, one for insights-client and other for rhcd. As rhcd it's not part of RHEL7.
