### PR TITLE
fix: path exists was reloading the service

### DIFF
--- a/insights-unregistered.path.in
+++ b/insights-unregistered.path.in
@@ -12,7 +12,7 @@ Description=Check if manually Unregistered from Red Hat Insights Client Path Wat
 Documentation=man:insights-client(8)
 
 [Path]
-PathExists=@sysconfdir@/insights-client/.unregistered
+PathModified=@sysconfdir@/insights-client/.unregistered
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Change to PathModified, to only acts when the .unregistered file is created and not continuously if it exists.

Solves: rhbz#2208224