### PR TITLE
Introduce a new redhat-cloud-client-configuration-cdn binary package

### DIFF
--- a/80-rhccc-disable-rhui-repos.preset
+++ b/80-rhccc-disable-rhui-repos.preset
@@ -1,0 +1,1 @@
+enable rhccc-disable-rhui-repos.service

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -197,8 +197,21 @@ fi
 
 
 %files
-%{_unitdir}/*
-%{_presetdir}/*
+%{_presetdir}/80-insights-register.preset
+%if 0%{?rhel} >= 8 || 0%{?fedora}
+%{_presetdir}/80-rhcd-register.preset
+%endif
+%{_unitdir}/insights-register.path
+%{_unitdir}/insights-register.service
+%{_unitdir}/insights-unregister.path
+%{_unitdir}/insights-unregister.service
+%{_unitdir}/insights-unregistered.path
+%{_unitdir}/insights-unregistered.service
+%if 0%{?rhel} >= 8 || 0%{?fedora}
+%{_unitdir}/rhcd-stop.path
+%{_unitdir}/rhcd-stop.service
+%{_unitdir}/rhcd.path
+%endif
 
 
 %changelog

--- a/rhccc-disable-rhui-repos.py
+++ b/rhccc-disable-rhui-repos.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import configparser
+import pathlib
+import sys
+
+
+def process_repo(p):
+    config = configparser.ConfigParser(interpolation=None)
+    try:
+        with p.open() as f:
+            config.read_file(f, str(p))
+        changed = 0
+        for section in config.sections():
+            try:
+                url = config.get(section, "mirrorlist", fallback=None) or config.get(
+                    section, "baseurl"
+                )
+                if "/rhui/" in url and config.getboolean(
+                    section, "enabled", fallback=True
+                ):
+                    config.set(section, "enabled", "0")
+                    changed += 1
+            except configparser.NoOptionError as e:
+                print(f"Warning when processing {p}: {e}", file=sys.stderr)
+        if changed > 0:
+            with p.open("w") as f:
+                config.write(f, space_around_delimiters=False)
+            print(f"Disabled {changed} repositories in {p}")
+    except Exception as e:
+        print(f"Error when processing {p}: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    for arg in sys.argv[1:]:
+        p = pathlib.Path(arg)
+        if p.is_file():
+            process_repo(p)
+        elif p.is_dir():
+            for child in p.iterdir():
+                if child.suffix == ".repo":
+                    process_repo(child)

--- a/rhccc-disable-rhui-repos.service.in
+++ b/rhccc-disable-rhui-repos.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run disable-rhui-repos on first boot
+ConditionPathExists=/etc/rhccc-firstboot-run
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/rm /etc/rhccc-firstboot-run
+ExecStart=-/usr/bin/touch /var/lib/rhui/disable-rhui
+ExecStart=@libexecdir@/rhccc-disable-rhui-repos.py /etc/yum.repos.d/
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The existing `redhat-cloud-client-configuration` binary package has a well-defined behaviour when used in cloud images:
- enable the subscription-manager automatic registration
- ensure that there is no content available by default from subscription repositories (and thus keep RHUI as source)

Since soon a different behaviour will be needed, then create a new `redhat-cloud-client-configuration-cdn` binary package to represent that behaviour separately:
- keep enabling the automatic registration
- do not disable the subscription repositories
- ensure to disable the non-public RHEL RHUI repositories:
  - use a "flag file" that soon will be introduced in the RHUI client packages for this
  - use a firstboot script that will disable the repositories; it will run in case `/etc/rhccc-firstboot-run` is there, which will be touch'ed when creating the cloud images with `redhat-cloud-client-configuration-cdn`

See the messages of the individual commits for more details.

Card ID: CCT-701