### PR TITLE
fix: autoregistration v2 - content should be enabled asap

### DIFF
--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -263,6 +263,8 @@ fi
 touch /var/lib/rhui/disable-rhui || :
 # Run following block only during installation (not during update)
 if [ $1 -eq 1 ]; then
+    rhsmcertd_restart_required=0
+    
     # Try to get current value of auto-registration in rhsm.conf
     subscription-manager config --list | grep -q '^[ \t]*auto_registration[ \t]*=[ \t]*1'
     if [ $? -eq 0 ]; then
@@ -271,8 +273,16 @@ if [ $1 -eq 1 ]; then
         auto_reg_enabled=0
     fi
 
+    # Try to get current value of manage_repos
+    subscription-manager config --list | grep -q '^[ \t]*manage_repos[ \t]*=[ \t]*0'
+    if [ $? -eq 0 ]; then
+        manage_repos_enabled=0
+    else
+        manage_repos_enabled=1
+    fi
+
     # When we are going to change any configuration value, then save original rhsm.conf
-    if [ $auto_reg_enabled -eq 0 ]; then
+    if [ $auto_reg_enabled -eq 0 -o $manage_repos_enabled -eq 0 ]; then
         echo -e "#\n# Automatic backup of rhsm.conf created by %{name}-cdn installation script\n#\n" \
             > /etc/rhsm/rhsm.conf.cloud_save
         cat /etc/rhsm/rhsm.conf >> /etc/rhsm/rhsm.conf.cloud_save
@@ -281,10 +291,18 @@ if [ $1 -eq 1 ]; then
     # Enable auto-registration in rhsm.conf
     if [ $auto_reg_enabled -eq 0 ]; then
         subscription-manager config --rhsmcertd.auto_registration=1
+        rhsmcertd_restart_required=1
+    fi
+
+    # Enable management of redhat.repo on systems running on
+    # public cloud and getting content from CDN
+    if [ $manage_repos_enabled -eq 0 ]; then
+        subscription-manager config --rhsm.manage_repos=1
+        rhsmcertd_restart_required=1
     fi
 
     # Restart rhsmcertd to reload configuration file, when it is necessary
-    if [ $auto_reg_enabled -eq 0 ]; then
+    if [ $rhsmcertd_restart_required -eq 1 ]; then
         /bin/systemctl restart rhsmcertd.service
     fi
 fi
@@ -331,6 +349,13 @@ if [ $1 -eq 0 ]; then
         grep -q '^[ \t]*auto_registration[ \t]*=[ \t]*0' /etc/rhsm/rhsm.conf.cloud_save
         if [ $? -eq 0 ]; then
             subscription-manager config --rhsmcertd.auto_registration=0
+            rhsmcertd_restart_required=1
+        fi
+
+        # When managing was originally disabled, then disable it again
+        grep -q '^[ \t]*manage_repos[ \t]*=[ \t]*0' /etc/rhsm/rhsm.conf.cloud_save
+        if [ $? -eq 0 ]; then
+            subscription-manager config --rhsm.manage_repos=0
             rhsmcertd_restart_required=1
         fi
 

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -273,6 +273,15 @@ if [ $1 -eq 1 ]; then
         auto_reg_enabled=0
     fi
 
+    # Try to get information if current value of auto_registration_interval in rhsm.conf
+    # has value 1 minute
+    subscription-manager config --list | grep -q '^[ \t]*auto_registration_interval[ \t]*=[ \t]*1'
+    if [ $? -eq 0 ]; then
+        auto_reg_interval_one_min=1
+    else
+        auto_reg_interval_one_min=0
+    fi
+
     # Try to get current value of manage_repos
     subscription-manager config --list | grep -q '^[ \t]*manage_repos[ \t]*=[ \t]*0'
     if [ $? -eq 0 ]; then
@@ -282,7 +291,7 @@ if [ $1 -eq 1 ]; then
     fi
 
     # When we are going to change any configuration value, then save original rhsm.conf
-    if [ $auto_reg_enabled -eq 0 -o $manage_repos_enabled -eq 0 ]; then
+    if [ $auto_reg_enabled -eq 0 -o $manage_repos_enabled -eq 0 -o $auto_reg_interval_one_min -eq 0 ]; then
         echo -e "#\n# Automatic backup of rhsm.conf created by %{name}-cdn installation script\n#\n" \
             > /etc/rhsm/rhsm.conf.cloud_save
         cat /etc/rhsm/rhsm.conf >> /etc/rhsm/rhsm.conf.cloud_save
@@ -291,6 +300,13 @@ if [ $1 -eq 1 ]; then
     # Enable auto-registration in rhsm.conf
     if [ $auto_reg_enabled -eq 0 ]; then
         subscription-manager config --rhsmcertd.auto_registration=1
+        rhsmcertd_restart_required=1
+    fi
+
+    # Set splay of auto-registration interval to one minute
+    # (set auto_registration_interval to 1 in rhsm.conf)
+    if [ $auto_reg_interval_one_min -eq 0 ]; then
+        subscription-manager config --rhsmcertd.auto_registration_interval=1
         rhsmcertd_restart_required=1
     fi
 
@@ -349,6 +365,14 @@ if [ $1 -eq 0 ]; then
         grep -q '^[ \t]*auto_registration[ \t]*=[ \t]*0' /etc/rhsm/rhsm.conf.cloud_save
         if [ $? -eq 0 ]; then
             subscription-manager config --rhsmcertd.auto_registration=0
+            rhsmcertd_restart_required=1
+        fi
+
+        # Was original interval one minute? If not, then restore original value.
+        grep -q '^[ \t]*auto_registration_interval[ \t]*=[ \t]*1' /etc/rhsm/rhsm.conf.cloud_save
+        if [ $? -ne 0 ]; then
+            original_interval=`sed -n 's/^[ \t]*auto_registration_interval[ \t]*=[ \t]*\(.*\)/\1/p' < /etc/rhsm/rhsm.conf.cloud_save`
+            subscription-manager config --rhsmcertd.auto_registration_interval=${original_interval}
             rhsmcertd_restart_required=1
         fi
 


### PR DESCRIPTION
* Card ID: CCT-1386
* Card ID: RHEL-90416
* Make sure that `manage_repos` is set to "1", when rhccc-cdn
  is installed. The default value of `manage_repos` is "1",
  but somebody could change it on image available on public
  cloud. For this reason it is good to enforce desired value
* Original value is restored, when rhccc-cdn is uninstalled
* When auto-registration v2 is used, then the
  splay should be very small to give systems
  performing auto-registration access to content
  on CDN as soon as possible
* The rhccc-cnd tries to set auto_registration_interval
  to one minute, because it influences the splay value
  of auto-registration. When auto-registration is used,
  then we want to provide access to content on CDN as
  soon as possible.
* The original values is restored, when rhccc-cdn is
  uninstalled