### PR TITLE
fix: Consider that yggdrasil is used on RHEL 10

### DIFF
--- a/80-yggdrasil-register.preset
+++ b/80-yggdrasil-register.preset
@@ -1,0 +1,2 @@
+enable yggdrasil.path
+enable yggdrasil-stop.path

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -5,6 +5,15 @@ Summary:        Red Hat cloud client configuration
 License:        GPL-2.0-or-later
 URL:            https://github.com/RedHatInsights/redhat-cloud-client-configuration
 
+# rhcd or yggdrasil
+%if 0%{?rhel} >= 8 || 0%{?fedora}
+%if 0%{?rhel} >= 10 || 0%{?fedora}
+%global service_name yggdrasil
+%else
+%global service_name rhcd
+%endif
+%endif
+
 # Sources can be obtained by
 # git clone https://github.com/rpm-software-management/tito
 # cd tito
@@ -25,6 +34,12 @@ Source12: insights-register.path.in
 Source13: rhccc-disable-rhui-repos.py
 Source14: rhccc-disable-rhui-repos.service.in
 Source15: 80-rhccc-disable-rhui-repos.preset
+# We cannot use ${service_name} here, because CI build system can create
+# SRPM on different platform than target platform, where RPM is built
+Source17: yggdrasil.path.in
+Source18: yggdrasil-stop.path.in
+Source19: yggdrasil-stop.service.in
+Source20: 80-yggdrasil-register.preset
 
 Source100: LICENSE
 
@@ -79,10 +94,16 @@ sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE6} > insights-unregistered.serv
 sed -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE14} > rhccc-disable-rhui-repos.service
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-# rhcd
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > rhcd.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > rhcd-stop.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > rhcd-stop.service
+# rhcd or yggdrasil
+%if 0%{?rhel} >= 10 || 0%{?fedora}
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > %{service_name}-stop.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > %{service_name}-stop.service
+%else
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE17} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE18} > %{service_name}-stop.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE19} > %{service_name}-stop.service
+%endif
 %endif
 
 %install
@@ -103,11 +124,15 @@ install %{SOURCE13} %{buildroot}%{_libexecdir}
 install -m644 %{SOURCE15} -t %{buildroot}%{_presetdir}/
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-# rhcd
-install -D -m644 rhcd.path %{buildroot}%{_unitdir}/
-install -D -m644 rhcd-stop.path %{buildroot}%{_unitdir}/
-install -D -m644 rhcd-stop.service %{buildroot}%{_unitdir}/
+# rhcd or yggdrasil
+install -D -m644 %{service_name}.path %{buildroot}%{_unitdir}/
+install -D -m644 %{service_name}-stop.path %{buildroot}%{_unitdir}/
+install -D -m644 %{service_name}-stop.service %{buildroot}%{_unitdir}/
+%if 0%{?rhel} >= 10 || 0%{?fedora}
+install -m644 %{SOURCE20} -t %{buildroot}%{_presetdir}/
+%else
 install -m644 %{SOURCE10} -t %{buildroot}%{_presetdir}/
+%endif
 %endif
 
 %post
@@ -115,10 +140,10 @@ install -m644 %{SOURCE10} -t %{buildroot}%{_presetdir}/
 %systemd_post insights-register.path
 %systemd_post insights-unregister.path
 %systemd_post insights-unregistered.path
-# rhcd
+# rhcd or yggdrasil
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_post rhcd.path
-%systemd_post rhcd-stop.path
+%systemd_post %{service_name}.path
+%systemd_post %{service_name}-stop.path
 %endif
 
 # Make sure that rhsmcertd.service is enabled and running
@@ -170,7 +195,7 @@ if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
     /bin/systemctl unmask --now insights-register.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-    /bin/systemctl unmask --now rhcd.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask --now %{service_name}.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path
@@ -178,8 +203,8 @@ fi
 %systemd_preun insights-unregistered.path
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_preun rhcd.path
-%systemd_preun rhcd-stop.path
+%systemd_preun %{service_name}.path
+%systemd_preun %{service_name}-stop.path
 %endif
 
 %postun
@@ -188,8 +213,8 @@ fi
 %systemd_postun insights-unregistered.path
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_postun rhcd.path
-%systemd_postun rhcd-stop.path
+%systemd_postun %{service_name}.path
+%systemd_postun %{service_name}-stop.path
 %endif
 
 
@@ -228,7 +253,7 @@ fi
 %files
 %{_presetdir}/80-insights-register.preset
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%{_presetdir}/80-rhcd-register.preset
+%{_presetdir}/80-%{service_name}-register.preset
 %endif
 %{_unitdir}/insights-register.path
 %{_unitdir}/insights-register.service
@@ -237,9 +262,9 @@ fi
 %{_unitdir}/insights-unregistered.path
 %{_unitdir}/insights-unregistered.service
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%{_unitdir}/rhcd-stop.path
-%{_unitdir}/rhcd-stop.service
-%{_unitdir}/rhcd.path
+%{_unitdir}/%{service_name}-stop.path
+%{_unitdir}/%{service_name}-stop.service
+%{_unitdir}/%{service_name}.path
 %endif
 
 
@@ -249,10 +274,10 @@ fi
 %systemd_post insights-unregister.path
 %systemd_post insights-unregistered.path
 %systemd_post rhccc-disable-rhui-repos.service
-# rhcd
+# rhcd or yggdrasil
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_post rhcd.path
-%systemd_post rhcd-stop.path
+%systemd_post %{service_name}.path
+%systemd_post %{service_name}-stop.path
 %endif
 
 # Make sure that rhsmcertd.service is enabled and running
@@ -294,7 +319,7 @@ if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
     /bin/systemctl unmask --now insights-register.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-    /bin/systemctl unmask --now rhcd.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask --now %{service_name}.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path
@@ -303,8 +328,8 @@ fi
 %systemd_preun rhccc-disable-rhui-repos.service
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_preun rhcd.path
-%systemd_preun rhcd-stop.path
+%systemd_preun %{service_name}.path
+%systemd_preun %{service_name}-stop.path
 %endif
 
 %postun cdn
@@ -314,8 +339,8 @@ fi
 %systemd_postun rhccc-disable-rhui-repos.service
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%systemd_postun rhcd.path
-%systemd_postun rhcd-stop.path
+%systemd_postun %{service_name}.path
+%systemd_postun %{service_name}-stop.path
 %endif
 
 rm -f /var/lib/rhui/disable-rhui
@@ -350,7 +375,7 @@ fi
 %{_presetdir}/80-insights-register.preset
 %{_presetdir}/80-rhccc-disable-rhui-repos.preset
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%{_presetdir}/80-rhcd-register.preset
+%{_presetdir}/80-%{service_name}-register.preset
 %endif
 %{_unitdir}/insights-register.path
 %{_unitdir}/insights-register.service
@@ -360,9 +385,9 @@ fi
 %{_unitdir}/insights-unregistered.service
 %{_unitdir}/rhccc-disable-rhui-repos.service
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-%{_unitdir}/rhcd-stop.path
-%{_unitdir}/rhcd-stop.service
-%{_unitdir}/rhcd.path
+%{_unitdir}/%{service_name}-stop.path
+%{_unitdir}/%{service_name}-stop.service
+%{_unitdir}/%{service_name}.path
 %endif
 
 

--- a/yggdrasil-stop.path.in
+++ b/yggdrasil-stop.path.in
@@ -1,0 +1,18 @@
+# This file is part of yggdrasil.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/yggdrasil-stop.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically stop yggdrasil by watching if rhsm cert exists
+Documentation=man:yggd(1)
+
+[Path]
+PathModified=@sysconfdir@/pki/consumer/cert.pem
+
+[Install]
+WantedBy=multi-user.target

--- a/yggdrasil-stop.service.in
+++ b/yggdrasil-stop.service.in
@@ -1,0 +1,20 @@
+# This file is part of yggdrasil.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/yggdrasil-stop.service.d/override.conf. Put the desired
+# overrides in that file and reload systemd. The next time this service is run
+# (either manually or via a systemd timer), the overridden values will be in
+# effect.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically stop yggdrasil when rhsm cert does not exists
+ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
+
+[Service]
+Type=simple
+ExecStart=/bin/systemctl stop yggdrasil.service
+ExecStopPost=/bin/systemctl unmask --now yggdrasil.path
+ExecStopPost=/bin/systemctl start yggdrasil.path

--- a/yggdrasil.path.in
+++ b/yggdrasil.path.in
@@ -1,0 +1,19 @@
+# This file is part of yggdrasil.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/yggdrasil.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+
+[Unit]
+Description=Automatically start yggdrasil with path watch
+Documentation=man:yggd(1)
+
+[Path]
+PathExists=@sysconfdir@/pki/consumer/cert.pem
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Card ID: CCT-1391
* When RHEL10 is used, then use yggdrasil.service and not rhcd.service
* Added files specific for yggdrasil
* Still install *rhcd* files on RHEL 8 and RHEL 9
* Install *yggdrasil* files on RHEL 10 and higher and Fedora