### PR TITLE
fix: Install rhcd* and yggdrasil* unit files correctly

### DIFF
--- a/insights-unregistered.service.in
+++ b/insights-unregistered.service.in
@@ -17,6 +17,6 @@ ConditionPathExists=@sysconfdir@/insights-client/.unregistered
 
 [Service]
 Type=simple
-ExecStart=/bin/systemctl unmask --now insights-register.path
+ExecStart=/bin/systemctl unmask insights-register.path
 ExecStop=/bin/systemctl start insights-register.path
 Restart=no

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -195,9 +195,9 @@ fi
 %preun
 if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
-    /bin/systemctl unmask --now insights-register.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask insights-register.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-    /bin/systemctl unmask --now %{service_name}.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask %{service_name}.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path
@@ -369,9 +369,9 @@ fi
 %preun cdn
 if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
-    /bin/systemctl unmask --now insights-register.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask insights-register.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-    /bin/systemctl unmask --now %{service_name}.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask %{service_name}.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -96,13 +96,15 @@ sed -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE14} > rhccc-disable-rhui-repos.
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 # rhcd or yggdrasil
 %if 0%{?rhel} >= 10 || 0%{?fedora}
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > %{service_name}.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > %{service_name}-stop.path
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > %{service_name}-stop.service
-%else
+# yggdrasil
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE17} > %{service_name}.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE18} > %{service_name}-stop.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE19} > %{service_name}-stop.service
+%else
+# rhcd
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > %{service_name}-stop.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > %{service_name}-stop.service
 %endif
 %endif
 

--- a/rhcd-stop.service.in
+++ b/rhcd-stop.service.in
@@ -16,5 +16,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=/bin/systemctl stop rhcd.service
-ExecStopPost=/bin/systemctl unmask --now rhcd.path
+ExecStopPost=/bin/systemctl unmask rhcd.path
 ExecStopPost=/bin/systemctl start rhcd.path

--- a/yggdrasil-stop.service.in
+++ b/yggdrasil-stop.service.in
@@ -16,5 +16,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=/bin/systemctl stop yggdrasil.service
-ExecStopPost=/bin/systemctl unmask --now yggdrasil.path
+ExecStopPost=/bin/systemctl unmask yggdrasil.path
 ExecStopPost=/bin/systemctl start yggdrasil.path


### PR DESCRIPTION
* Card ID: RHEL-101898
* Card ID: RHEL-107525 (RHEL-10)
* Card ID: RHEL-107527 (RHEL-9)
* The `rhcd.path`, `rhcd-stop.path` and `rhcd-stop.service` were installed
  as `yggdrasil.path`, `yggdrasil-stop.path` and `yggdrasil-stop.service`
  on RHEL 10. The yggdrasil* unit files were probably installed
  as rhcd* unit files on RHEL 9
* The `systemct unmask <service_name>` does not have CLI
  option `--now`. This CLI option is no-op. Using this
  option only cause annoying log messages.