### PR TITLE
Skip Insights/yggdrasil for anonymous RHSM consumers (CCT-2110)

### DIFF
--- a/insights-register-cgroupv1.service.in
+++ b/insights-register-cgroupv1.service.in
@@ -16,6 +16,7 @@ After=network-online.target
 
 [Service]
 Type=simple
+ExecCondition=@libexecdir@/rhccc-owner-allows-mtls-consumer.py
 ExecStart=@bindir@/insights-client --register
 Restart=no
 WatchdogSec=900

--- a/insights-register.path.in
+++ b/insights-register.path.in
@@ -13,6 +13,8 @@ Documentation=man:insights-client(8)
 
 [Path]
 PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=/var/lib/rhsm/cache/current_owner.json
 
 [Install]
 WantedBy=multi-user.target

--- a/insights-register.service.in
+++ b/insights-register.service.in
@@ -16,6 +16,7 @@ After=network-online.target
 
 [Service]
 Type=simple
+ExecCondition=@libexecdir@/rhccc-owner-allows-mtls-consumer.py
 ExecStart=@bindir@/insights-client --register
 Restart=no
 WatchdogSec=900

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -1,6 +1,6 @@
 Name:           redhat-cloud-client-configuration
 Version:        1
-Release:        15%{?dist}
+Release:        17%{?dist}
 Summary:        Red Hat cloud client configuration
 License:        GPL-2.0-or-later
 URL:            https://github.com/RedHatInsights/redhat-cloud-client-configuration
@@ -40,6 +40,8 @@ Source17: yggdrasil.path.in
 Source18: yggdrasil-stop.path.in
 Source19: yggdrasil-stop.service.in
 Source20: 80-yggdrasil-register.preset
+Source21: rhccc-owner-allows-mtls-consumer.py
+Source23: rhccc-mtls-consumer.service.conf.in
 
 Source100: LICENSE
 
@@ -83,9 +85,12 @@ to Red Hat's CDN.
 # insights-client
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE12} > insights-register.path
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-sed -e 's|@bindir@|%{_bindir}|g' %{SOURCE1} > insights-register.service
+sed -e 's|@bindir@|%{_bindir}|g' -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE1} > insights-register.service
 %else
-sed -e 's|@bindir@|%{_bindir}|g' %{SOURCE11} > insights-register.service
+sed -e 's|@bindir@|%{_bindir}|g' -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE11} > insights-register.service
+%endif
+%if 0%{?rhel} == 7
+sed -i '/^ExecCondition=/d' insights-register.service
 %endif
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE2} > insights-unregister.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@bindir@|%{_bindir}|g' %{SOURCE3} > insights-unregister.service
@@ -97,15 +102,17 @@ sed -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE14} > rhccc-disable-rhui-repos.
 # rhcd or yggdrasil
 %if 0%{?rhel} >= 10 || 0%{?fedora}
 # yggdrasil
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE17} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE17} > %{service_name}.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE18} > %{service_name}-stop.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE19} > %{service_name}-stop.service
 %else
 # rhcd
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE7} > %{service_name}.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > %{service_name}-stop.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > %{service_name}-stop.service
 %endif
+install -d rhccc-mtls-consumer.service.d
+sed -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE23} > rhccc-mtls-consumer.service.d/rhccc-mtls-consumer.conf
 %endif
 
 %install
@@ -123,6 +130,7 @@ install -m644 %{SOURCE4} -t %{buildroot}%{_presetdir}/
 
 install -d %{buildroot}%{_libexecdir}
 install %{SOURCE13} %{buildroot}%{_libexecdir}
+install -m755 %{SOURCE21} %{buildroot}%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 install -m644 %{SOURCE15} -t %{buildroot}%{_presetdir}/
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
@@ -130,6 +138,8 @@ install -m644 %{SOURCE15} -t %{buildroot}%{_presetdir}/
 install -D -m644 %{service_name}.path %{buildroot}%{_unitdir}/
 install -D -m644 %{service_name}-stop.path %{buildroot}%{_unitdir}/
 install -D -m644 %{service_name}-stop.service %{buildroot}%{_unitdir}/
+install -d %{buildroot}%{_unitdir}/%{service_name}.service.d
+install -m644 rhccc-mtls-consumer.service.d/rhccc-mtls-consumer.conf %{buildroot}%{_unitdir}/%{service_name}.service.d/
 %if 0%{?rhel} >= 10 || 0%{?fedora}
 install -m644 %{SOURCE20} -t %{buildroot}%{_presetdir}/
 %else
@@ -263,10 +273,12 @@ fi
 %{_unitdir}/insights-unregister.service
 %{_unitdir}/insights-unregistered.path
 %{_unitdir}/insights-unregistered.service
+%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %{_unitdir}/%{service_name}-stop.path
 %{_unitdir}/%{service_name}-stop.service
 %{_unitdir}/%{service_name}.path
+%{_unitdir}/%{service_name}.service.d/rhccc-mtls-consumer.conf
 %endif
 
 
@@ -459,14 +471,29 @@ fi
 %{_unitdir}/insights-unregistered.path
 %{_unitdir}/insights-unregistered.service
 %{_unitdir}/rhccc-disable-rhui-repos.service
+%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %{_unitdir}/%{service_name}-stop.path
 %{_unitdir}/%{service_name}-stop.service
 %{_unitdir}/%{service_name}.path
+%{_unitdir}/%{service_name}.service.d/rhccc-mtls-consumer.conf
 %endif
 
 
 %changelog
+* Wed May 06 2026 Chris Snyder <csnyder@redhat.com> - 1-17
+- Address CCT-2110 review: use RHSM D-Bus Consumer.GetOrg instead of parsing
+  current_owner.json; install ExecCondition as a drop-in on the cloud daemon
+  service and point path units at %{service_name}.service again; drop
+  rhccc-start-cloud-daemon.service and the extra openssl Requires.
+
+* Wed Apr 29 2026 Chris Snyder <csnyder@redhat.com> - 1-16
+- Skip insights-client registration and yggdrasil/rhcd start for anonymous RHSM
+  consumers (CCT-2110): ExecCondition on owner cache vs consumer cert UUID,
+  PathChanged on cert and current_owner.json, indirect start via
+  rhccc-start-cloud-daemon.service.
+- Add explicit openssl dependency for the owner check helper.
+
 * Wed Sep 14 2022 Gael Chamoulaud <gchamoul@redhat.com> - 1-1
 - Remove preset files from %post directive
 

--- a/rhccc-mtls-consumer.service.conf.in
+++ b/rhccc-mtls-consumer.service.conf.in
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Drop-in: skip starting the cloud device daemon while the RHSM consumer is
+# anonymous (see rhccc-owner-allows-mtls-consumer.py).
+
+[Service]
+ExecCondition=@libexecdir@/rhccc-owner-allows-mtls-consumer.py

--- a/rhccc-owner-allows-mtls-consumer.py
+++ b/rhccc-owner-allows-mtls-consumer.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# systemd ExecCondition helper for redhat-cloud-client-configuration (CCT-2110).
+# Exit 0  — consumer is suitable for mTLS-backed services (run ExecStart).
+# Exit 75 — skip ExecStart (anonymous owner for this consumer); unit succeeds.
+# Other   — configuration error; unit fails.
+#
+# Uses ``busctl call ... GetOrg`` (com.redhat.RHSM1.Consumer) for the current
+# owner JSON (same data subscription-manager exposes). Missing cert, D-Bus
+# errors, or unreadable owner JSON return 75 so the ExecCondition is considered
+# failed and systemd skips the remainder of the unit without marking the unit
+# as failed(see systemd.service ExecCondition=).
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, Optional
+
+# systemd.exec(5): "If the ExecCondition= exits with 75, the job is considered
+# successful but skipped"
+_SYSTEMD_SKIP_UNIT = 75
+
+_CERT = "/etc/pki/consumer/cert.pem"
+
+# Current owner JSON from subscription-manager (same as:
+#   busctl call --json=short com.redhat.RHSM1 \
+#    /com/redhat/RHSM1/Consumer \
+#     com.redhat.RHSM1.Consumer GetOrg s ""
+_GET_ORG_BUSCTL = (
+    "busctl",
+    "call",
+    "--json=short",
+    "com.redhat.RHSM1",
+    "/com/redhat/RHSM1/Consumer",
+    "com.redhat.RHSM1.Consumer",
+    "GetOrg",
+    "s",
+    "",
+)
+
+
+def _parse_busctl_output(busctl_out: str) -> Optional[str]:
+    """Decode the output of the busctl call."""
+    
+    try:
+        response = json.loads(busctl_out)
+        data = response.get('data')[0]
+        data = data[0]
+        org_info = json.loads(data)
+    except:
+        # If parsing fails for any reason assume we don't have owner info
+        return None
+    
+    return org_info
+
+def _owner_dict_from_rhsm_dbus() -> Optional[Dict[str, Any]]:
+    """
+    Return the current owner dict via ``busctl call`` to Consumer.GetOrg.
+
+    Invokes:
+    ``busctl call --json=short com.redhat.RHSM1 /com/redhat/RHSM1/Consumer
+    com.redhat.RHSM1.Consumer GetOrg s ""``
+
+    GetOrg returns a JSON string of the owner record (including ``anonymous``).
+    Returns None if the call fails, the payload is not a JSON object, or the
+    response cannot be parsed.
+    """
+    try:
+        proc = subprocess.run(
+            list(_GET_ORG_BUSCTL),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    return _parse_busctl_output(proc.stdout)
+
+
+def main() -> int:
+    # No consumer cert: not in a state we gate on; ExecCondition succeeds (0).
+    if not os.path.isfile(_CERT):
+        return _SYSTEMD_SKIP_UNIT
+    owner = _owner_dict_from_rhsm_dbus()
+    if owner is None:
+        return _SYSTEMD_SKIP_UNIT
+    if owner.get("anonymous") is True:
+        return _SYSTEMD_SKIP_UNIT
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rhcd.path.in
+++ b/rhcd.path.in
@@ -14,6 +14,8 @@ Documentation=man:rhcd(8)
 
 [Path]
 PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
 
 [Install]
 WantedBy=multi-user.target

--- a/yggdrasil.path.in
+++ b/yggdrasil.path.in
@@ -14,6 +14,8 @@ Documentation=man:yggd(1)
 
 [Path]
 PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add rhccc-owner-allows-mtls-consumer.py as systemd ExecCondition: exit 75 when current_owner.json matches the consumer cert CN and anonymous is true. Otherwise allow registration and daemon start; mismatched cache keys are ignored as stale.

Wire yggdrasil/rhcd path units to rhccc-start-cloud-daemon oneshot so we do not patch upstream service units. Add PathChanged on cert.pem and current_owner.json so anonymous-to-claimed transitions re-trigger.

Strip ExecCondition on RHEL 7 builds (systemd without ExecCondition). Require openssl for the cert subject probe.

Related: RHEL-158888
