### PR TITLE
Skip Insights and cloud daemon start for anonymous RHSM owners

### DIFF
--- a/80-insights-register.preset
+++ b/80-insights-register.preset
@@ -1,3 +1,4 @@
 enable insights-register.path
+enable insights-register-pathexists.path
 enable insights-unregister.path
 enable insights-unregistered.path

--- a/80-rhccc-mtls-consumer.service.conf.in
+++ b/80-rhccc-mtls-consumer.service.conf.in
@@ -1,0 +1,8 @@
+# Drop-in: skip starting the cloud device daemon while the RHSM consumer is anonymous
+# (see rhccc-owner-allows-mtls-consumer.py).
+# (At the time of writing the cloud device daemon is either yggdrasil/yggd or rhcd)
+# This file was built and installed for (@service_name@.service)
+
+[Service]
+ExecCondition=+@libexecdir@/rhccc-owner-allows-mtls-consumer.py
+ExecStopPost=+/bin/systemctl mask --now @service_name@-pathexists.path

--- a/80-rhcd-register.preset
+++ b/80-rhcd-register.preset
@@ -1,2 +1,3 @@
 enable rhcd.path
+enable rhcd-pathexists.path
 enable rhcd-stop.path

--- a/80-yggdrasil-register.preset
+++ b/80-yggdrasil-register.preset
@@ -1,2 +1,3 @@
 enable yggdrasil.path
+enable yggdrasil-pathexists.path
 enable yggdrasil-stop.path

--- a/insights-register-cgroupv1.service.in
+++ b/insights-register-cgroupv1.service.in
@@ -16,6 +16,7 @@ After=network-online.target
 
 [Service]
 Type=simple
+ExecCondition=@libexecdir@/rhccc-owner-allows-mtls-consumer.py
 ExecStart=@bindir@/insights-client --register
 Restart=no
 WatchdogSec=900

--- a/insights-register-pathexists.path.in
+++ b/insights-register-pathexists.path.in
@@ -1,0 +1,51 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-register.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+#
+# This separate systemd path unit is necessary due primarily to this line
+# from the systemd.path man page:
+# "When a service unit triggered by a path unit terminates (regardless
+# whether it exited successfully or failed), monitored paths are checked
+# immediately again, and the service accordingly restarted instantly."
+#
+# PathExists triggers as soon as the file indicated by the value of the
+# directive goes from nonexistent to existent (as soon as the matching path
+# is created) and will check once again for path existence as soon as the
+# associated service unit exits (or in the case of an ExecCondition on the
+# service unit, as soon as the ExecCondition finishes running if it returns
+# false / non-zero exit code.). This means that very quickly the path unit
+# using PathExists will be put into a failed state by systemd (due to hitting
+# the trigger limit). As it might be alarming for sysadmins to see a failed
+# systemd unit (especially when the overall system of rhccc expects
+# the path unit containing PathExists to only execute once per new
+# registration) and in order to allow us to trigger the
+# insights-register.service again when the consumer certificate is updated,
+# we therefore need two separate triggers for insights-register.service.
+# One for existance that only runs once when the consumer certificate is
+# created and is reset when the consumer certificate is deleted (this file).
+# And a second path unit using PathChanged to check a changed consumer
+# certificate to see if the system is now registered to a non-anonymous
+# organization (insights-register.path).
+#
+# As an implementation detail, to allow for the trigger on path existence
+# but prevent unneeded busy-looping, the insights-register.service now
+# has an ExecStopPost which masks this path unit. ExecStopPost is executed
+# after the service defined in a service unit exits (or in our case after
+# the ExecCondition runs and prevents the main ExecStart from running).
+# ExecStop direcives only run after the ExecStart runs and exits.
+
+[Unit]
+Description=Automatically Register with Red Hat Insights Path Watch (newly registered)
+Documentation=man:insights-client(8)
+
+[Path]
+PathExists=@sysconfdir@/pki/consumer/cert.pem
+Unit=insights-register.service
+
+[Install]
+WantedBy=multi-user.target

--- a/insights-register.path.in
+++ b/insights-register.path.in
@@ -12,7 +12,7 @@ Description=Automatically Register with Red Hat Insights Path Watch
 Documentation=man:insights-client(8)
 
 [Path]
-PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
 
 [Install]
 WantedBy=multi-user.target

--- a/insights-register.service.in
+++ b/insights-register.service.in
@@ -16,6 +16,7 @@ After=network-online.target
 
 [Service]
 Type=simple
+ExecCondition=@libexecdir@/rhccc-owner-allows-mtls-consumer.py
 ExecStart=@bindir@/insights-client --register
 Restart=no
 WatchdogSec=900
@@ -26,4 +27,5 @@ TasksMax=300
 BlockIOWeight=100
 ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.memsw.limit_in_bytes"
 ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.soft_limit_in_bytes"
-ExecStopPost=/bin/systemctl mask --now insights-register.path
+ExecStop=/bin/systemctl mask --now insights-register.path
+ExecStopPost=/bin/systemctl mask --now insights-register-pathexists.path

--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -40,6 +40,11 @@ Source17: yggdrasil.path.in
 Source18: yggdrasil-stop.path.in
 Source19: yggdrasil-stop.service.in
 Source20: 80-yggdrasil-register.preset
+Source21: rhccc-owner-allows-mtls-consumer.py
+Source23: 80-rhccc-mtls-consumer.service.conf.in
+Source24: insights-register-pathexists.path.in
+Source25: yggdrasil-pathexists.path.in
+Source26: rhcd-pathexists.path.in
 
 Source100: LICENSE
 
@@ -82,10 +87,14 @@ to Red Hat's CDN.
 %build
 # insights-client
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE12} > insights-register.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE24} > insights-register-pathexists.path
 %if 0%{?rhel} >= 8 || 0%{?fedora}
-sed -e 's|@bindir@|%{_bindir}|g' %{SOURCE1} > insights-register.service
+sed -e 's|@bindir@|%{_bindir}|g' -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE1} > insights-register.service
 %else
-sed -e 's|@bindir@|%{_bindir}|g' %{SOURCE11} > insights-register.service
+sed -e 's|@bindir@|%{_bindir}|g' -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE11} > insights-register.service
+%endif
+%if 0%{?rhel} == 7
+sed -i '/^ExecCondition=/d' insights-register.service
 %endif
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE2} > insights-unregister.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@bindir@|%{_bindir}|g' %{SOURCE3} > insights-unregister.service
@@ -97,20 +106,25 @@ sed -e 's|@libexecdir@|%{_libexecdir}|g' %{SOURCE14} > rhccc-disable-rhui-repos.
 # rhcd or yggdrasil
 %if 0%{?rhel} >= 10 || 0%{?fedora}
 # yggdrasil
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE17} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE17} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE25} > %{service_name}-pathexists.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE18} > %{service_name}-stop.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE19} > %{service_name}-stop.service
 %else
 # rhcd
-sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE7} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE7} > %{service_name}.path
+sed -e 's|@sysconfdir@|%{_sysconfdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE26} > %{service_name}-pathexists.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE8} > %{service_name}-stop.path
 sed -e 's|@sysconfdir@|%{_sysconfdir}|g' %{SOURCE9} > %{service_name}-stop.service
 %endif
+install -d %{service_name}.service.d
+sed -e 's|@libexecdir@|%{_libexecdir}|g' -e 's|@service_name@|%{service_name}|g' %{SOURCE23} > %{service_name}.service.d/80-rhccc-mtls-consumer.conf
 %endif
 
 %install
 # insights-client
 install -d %{buildroot}%{_unitdir}
+install -m644 insights-register-pathexists.path %{buildroot}%{_unitdir}/
 install -m644 insights-register.path    %{buildroot}%{_unitdir}/
 install -m644 insights-register.service %{buildroot}%{_unitdir}/
 install -m644 insights-unregister.path    %{buildroot}%{_unitdir}/
@@ -123,13 +137,17 @@ install -m644 %{SOURCE4} -t %{buildroot}%{_presetdir}/
 
 install -d %{buildroot}%{_libexecdir}
 install %{SOURCE13} %{buildroot}%{_libexecdir}
+install -m755 %{SOURCE21} %{buildroot}%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 install -m644 %{SOURCE15} -t %{buildroot}%{_presetdir}/
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 # rhcd or yggdrasil
 install -D -m644 %{service_name}.path %{buildroot}%{_unitdir}/
+install -D -m644 %{service_name}-pathexists.path %{buildroot}%{_unitdir}/
 install -D -m644 %{service_name}-stop.path %{buildroot}%{_unitdir}/
 install -D -m644 %{service_name}-stop.service %{buildroot}%{_unitdir}/
+install -d %{buildroot}%{_unitdir}/%{service_name}.service.d
+install -m644 %{service_name}.service.d/80-rhccc-mtls-consumer.conf %{buildroot}%{_unitdir}/%{service_name}.service.d/
 %if 0%{?rhel} >= 10 || 0%{?fedora}
 install -m644 %{SOURCE20} -t %{buildroot}%{_presetdir}/
 %else
@@ -140,11 +158,13 @@ install -m644 %{SOURCE10} -t %{buildroot}%{_presetdir}/
 %post
 # insights-client
 %systemd_post insights-register.path
+%systemd_post insights-register-pathexists.path
 %systemd_post insights-unregister.path
 %systemd_post insights-unregistered.path
 # rhcd or yggdrasil
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_post %{service_name}.path
+%systemd_post %{service_name}-pathexists.path
 %systemd_post %{service_name}-stop.path
 %endif
 
@@ -196,26 +216,32 @@ fi
 if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
     /bin/systemctl unmask insights-register.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask insights-register-pathexists.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
     /bin/systemctl unmask %{service_name}.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask %{service_name}-pathexists.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path
+%systemd_preun insights-register-pathexists.path
 %systemd_preun insights-unregister.path
 %systemd_preun insights-unregistered.path
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_preun %{service_name}.path
+%systemd_preun %{service_name}-pathexists.path
 %systemd_preun %{service_name}-stop.path
 %endif
 
 %postun
 %systemd_postun insights-register.path
+%systemd_postun insights-register-pathexists.path
 %systemd_postun insights-unregister.path
 %systemd_postun insights-unregistered.path
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_postun %{service_name}.path
+%systemd_postun %{service_name}-pathexists.path
 %systemd_postun %{service_name}-stop.path
 %endif
 
@@ -258,27 +284,33 @@ fi
 %{_presetdir}/80-%{service_name}-register.preset
 %endif
 %{_unitdir}/insights-register.path
+%{_unitdir}/insights-register-pathexists.path
 %{_unitdir}/insights-register.service
 %{_unitdir}/insights-unregister.path
 %{_unitdir}/insights-unregister.service
 %{_unitdir}/insights-unregistered.path
 %{_unitdir}/insights-unregistered.service
+%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %{_unitdir}/%{service_name}-stop.path
 %{_unitdir}/%{service_name}-stop.service
 %{_unitdir}/%{service_name}.path
+%{_unitdir}/%{service_name}-pathexists.path
+%{_unitdir}/%{service_name}.service.d/80-rhccc-mtls-consumer.conf
 %endif
 
 
 %post cdn
 # insights-client
 %systemd_post insights-register.path
+%systemd_post insights-register-pathexists.path
 %systemd_post insights-unregister.path
 %systemd_post insights-unregistered.path
 %systemd_post rhccc-disable-rhui-repos.service
 # rhcd or yggdrasil
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_post %{service_name}.path
+%systemd_post %{service_name}-pathexists.path
 %systemd_post %{service_name}-stop.path
 %endif
 
@@ -370,28 +402,34 @@ fi
 if [ $1 -eq 0 ]; then
     # Packager removal, unmask register if exists
     /bin/systemctl unmask insights-register.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask insights-register-pathexists.path > /dev/null 2>&1 || :
 %if 0%{?rhel} >= 8 || 0%{?fedora}
     /bin/systemctl unmask %{service_name}.path > /dev/null 2>&1 || :
+    /bin/systemctl unmask %{service_name}-pathexists.path > /dev/null 2>&1 || :
 %endif
 fi
 %systemd_preun insights-register.path
+%systemd_preun insights-register-pathexists.path
 %systemd_preun insights-unregister.path
 %systemd_preun insights-unregistered.path
 %systemd_preun rhccc-disable-rhui-repos.service
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_preun %{service_name}.path
+%systemd_preun %{service_name}-pathexists.path
 %systemd_preun %{service_name}-stop.path
 %endif
 
 %postun cdn
 %systemd_postun insights-register.path
+%systemd_postun insights-register-pathexists.path
 %systemd_postun insights-unregister.path
 %systemd_postun insights-unregistered.path
 %systemd_postun rhccc-disable-rhui-repos.service
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %systemd_postun %{service_name}.path
+%systemd_postun %{service_name}-pathexists.path
 %systemd_postun %{service_name}-stop.path
 %endif
 
@@ -453,16 +491,20 @@ fi
 %{_presetdir}/80-%{service_name}-register.preset
 %endif
 %{_unitdir}/insights-register.path
+%{_unitdir}/insights-register-pathexists.path
 %{_unitdir}/insights-register.service
 %{_unitdir}/insights-unregister.path
 %{_unitdir}/insights-unregister.service
 %{_unitdir}/insights-unregistered.path
 %{_unitdir}/insights-unregistered.service
 %{_unitdir}/rhccc-disable-rhui-repos.service
+%{_libexecdir}/rhccc-owner-allows-mtls-consumer.py
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 %{_unitdir}/%{service_name}-stop.path
 %{_unitdir}/%{service_name}-stop.service
 %{_unitdir}/%{service_name}.path
+%{_unitdir}/%{service_name}-pathexists.path
+%{_unitdir}/%{service_name}.service.d/80-rhccc-mtls-consumer.conf
 %endif
 
 

--- a/rhccc-owner-allows-mtls-consumer.py
+++ b/rhccc-owner-allows-mtls-consumer.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# systemd ExecCondition helper for redhat-cloud-client-configuration (CCT-2110).
+# Exit 0  — consumer is suitable for mTLS-backed services (run ExecStart).
+# Exit 75 — skip ExecStart (anonymous owner for this consumer); unit succeeds.
+# Other   — configuration error; unit fails.
+#
+# Uses ``busctl call ... GetOrg`` (com.redhat.RHSM1.Consumer) for the current
+# owner JSON (same data subscription-manager exposes). Missing cert, D-Bus
+# errors, or unreadable owner JSON return 75 so the ExecCondition is considered
+# failed and systemd skips the remainder of the unit without marking the unit
+# as failed(see systemd.service ExecCondition=).
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, Optional
+
+# systemd.exec(5): "If the ExecCondition= exits with 75, the job is considered
+# successful but skipped"
+_SYSTEMD_SKIP_UNIT = 75
+
+_CERT = "/etc/pki/consumer/cert.pem"
+
+# Current owner JSON from subscription-manager (same as:
+#   busctl call --json=short com.redhat.RHSM1 \
+#    /com/redhat/RHSM1/Consumer \
+#     com.redhat.RHSM1.Consumer GetOrg s ""
+_GET_ORG_BUSCTL = (
+    "busctl",
+    "call",
+    "--json=short",
+    "com.redhat.RHSM1",
+    "/com/redhat/RHSM1/Consumer",
+    "com.redhat.RHSM1.Consumer",
+    "GetOrg",
+    "s",
+    "",
+)
+
+
+def _parse_busctl_output(busctl_out: str) -> Optional[str]:
+    """Decode the output of the busctl call."""
+
+    try:
+        response = json.loads(busctl_out)
+        data = response.get('data')[0]
+        org_info = json.loads(data)
+    except:
+        # If parsing fails for any reason assume we don't have owner info
+        return None
+
+    return org_info
+
+def _owner_dict_from_rhsm_dbus() -> Optional[Dict[str, Any]]:
+    """
+    Return the current owner dict via ``busctl call`` to Consumer.GetOrg.
+
+    Invokes:
+    ``busctl call --json=short com.redhat.RHSM1 /com/redhat/RHSM1/Consumer
+    com.redhat.RHSM1.Consumer GetOrg s ""``
+
+    GetOrg returns a JSON string of the owner record (including ``anonymous``).
+    Returns None if the call fails, the payload is not a JSON object, or the
+    response cannot be parsed.
+    """
+    try:
+        proc = subprocess.run(
+            list(_GET_ORG_BUSCTL),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    return _parse_busctl_output(proc.stdout)
+
+
+def main() -> int:
+    # No consumer cert: not in a state we gate on; ExecCondition succeeds (0).
+    if not os.path.isfile(_CERT):
+        return _SYSTEMD_SKIP_UNIT
+    owner = _owner_dict_from_rhsm_dbus()
+    if owner is None:
+        return _SYSTEMD_SKIP_UNIT
+    # In the case that the "anonymous" attribute does not exist this also means
+    # the owner/org is not anonymous
+    if owner.get("anonymous") is True:
+        return _SYSTEMD_SKIP_UNIT
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rhcd-pathexists.path.in
+++ b/rhcd-pathexists.path.in
@@ -1,0 +1,52 @@
+# This file is part of rhcd.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/rhcd-pathexists.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+#
+# This separate systemd path unit is necessary due primarily to this line
+# from the systemd.path man page:
+# "When a service unit triggered by a path unit terminates (regardless
+# whether it exited successfully or failed), monitored paths are checked
+# immediately again, and the service accordingly restarted instantly."
+#
+# PathExists triggers as soon as the file indicated by the value of the
+# directive goes from nonexistent to existent (as soon as the matching path
+# is created) and will check once again for path existence as soon as the
+# associated service unit exits (or in the case of an ExecCondition on the
+# service unit, as soon as the ExecCondition finishes running if it returns
+# false / non-zero exit code.). This means that very quickly the path unit
+# using PathExists will be put into a failed state by systemd (due to hitting
+# the trigger limit). As it might be alarming for sysadmins to see a failed
+# systemd unit (especially when the overall system of rhccc expects
+# the path unit containing PathExists to only execute once per new
+# registration) and in order to allow us to trigger the
+# insights-register.service again when the consumer certificate is updated,
+# we therefore need two separate triggers for insights-register.service.
+# One for existance that only runs once when the consumer certificate is
+# created and is reset when the consumer certificate is deleted (this file).
+# And a second path unit using PathChanged to check a changed consumer
+# certificate to see if the system is now registered to a non-anonymous
+# organization (insights-register.path).
+#
+# As an implementation detail, to allow for the trigger on path existence
+# but prevent unneeded busy-looping, the insights-register.service now
+# has an ExecStopPost which masks this path unit. ExecStopPost is executed
+# after the service defined in a service unit exits (or in our case after
+# the ExecCondition runs and prevents the main ExecStart from running).
+# ExecStop direcives only run after the ExecStart runs and exits.
+
+
+[Unit]
+Description=Automatically start rhcd with path watch (newly registered)
+Documentation=man:rhcd(8)
+
+[Path]
+PathExists=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
+
+[Install]
+WantedBy=multi-user.target

--- a/rhcd-stop.service.in
+++ b/rhcd-stop.service.in
@@ -16,5 +16,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=/bin/systemctl stop rhcd.service
-ExecStopPost=/bin/systemctl unmask rhcd.path
-ExecStopPost=/bin/systemctl start rhcd.path
+ExecStopPost=/bin/systemctl unmask rhcd.path rhcd-pathexists.path
+ExecStopPost=/bin/systemctl start rhcd.path rhcd-pathexists.path

--- a/rhcd.path.in
+++ b/rhcd.path.in
@@ -13,7 +13,8 @@ Description=Automatically start rhcd with path watch
 Documentation=man:rhcd(8)
 
 [Path]
-PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
 
 [Install]
 WantedBy=multi-user.target

--- a/yggdrasil-pathexists.path.in
+++ b/yggdrasil-pathexists.path.in
@@ -1,0 +1,52 @@
+# This file is part of yggdrasil.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/yggdrasil-pathexists.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+#
+# This separate systemd path unit is necessary due primarily to this line
+# from the systemd.path man page:
+# "When a service unit triggered by a path unit terminates (regardless
+# whether it exited successfully or failed), monitored paths are checked
+# immediately again, and the service accordingly restarted instantly."
+#
+# PathExists triggers as soon as the file indicated by the value of the
+# directive goes from nonexistent to existent (as soon as the matching path
+# is created) and will check once again for path existence as soon as the
+# associated service unit exits (or in the case of an ExecCondition on the
+# service unit, as soon as the ExecCondition finishes running if it returns
+# false / non-zero exit code.). This means that very quickly the path unit
+# using PathExists will be put into a failed state by systemd (due to hitting
+# the trigger limit). As it might be alarming for sysadmins to see a failed
+# systemd unit (especially when the overall system of rhccc expects
+# the path unit containing PathExists to only execute once per new
+# registration) and in order to allow us to trigger the
+# insights-register.service again when the consumer certificate is updated,
+# we therefore need two separate triggers for insights-register.service.
+# One for existance that only runs once when the consumer certificate is
+# created and is reset when the consumer certificate is deleted (this file).
+# And a second path unit using PathChanged to check a changed consumer
+# certificate to see if the system is now registered to a non-anonymous
+# organization (insights-register.path).
+#
+# As an implementation detail, to allow for the trigger on path existence
+# but prevent unneeded busy-looping, the insights-register.service now
+# has an ExecStopPost which masks this path unit. ExecStopPost is executed
+# after the service defined in a service unit exits (or in our case after
+# the ExecCondition runs and prevents the main ExecStart from running).
+# ExecStop direcives only run after the ExecStart runs and exits.
+
+
+[Unit]
+Description=Automatically start yggdrasil with path watch (newly registered)
+Documentation=man:yggd(1)
+
+[Path]
+PathExists=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
+
+[Install]
+WantedBy=multi-user.target

--- a/yggdrasil-stop.service.in
+++ b/yggdrasil-stop.service.in
@@ -16,5 +16,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=/bin/systemctl stop yggdrasil.service
-ExecStopPost=/bin/systemctl unmask yggdrasil.path
-ExecStopPost=/bin/systemctl start yggdrasil.path
+ExecStopPost=/bin/systemctl unmask yggdrasil.path yggdrasil-pathexists.path
+ExecStopPost=/bin/systemctl start yggdrasil.path yggdrasil-pathexists.path

--- a/yggdrasil.path.in
+++ b/yggdrasil.path.in
@@ -13,7 +13,8 @@ Description=Automatically start yggdrasil with path watch
 Documentation=man:yggd(1)
 
 [Path]
-PathExists=@sysconfdir@/pki/consumer/cert.pem
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+Unit=@service_name@.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# What is this change?
This PR and the related change in subscription-manager collectively ensure that upon automatic registration to an anonymous org (AFAIK only supported for systems running in supported cloud environments) said system will *not* automatically attempt registration with insights *nor* kick off yggdrasil as these tools are not intended to work with anonymous/unclaimed consumers.

This PR also ensures that when the system is claimed and then now belongs to a non-anonymous org that registration is performed with insights-client and yggdrasil is started.

Please note that the instructions below do not mock out the services that insights-client and yggdrasil talk to so in verifying do not expect these services to succeed, just to be triggered when they should be and not be triggered when they should not be.

As of this PR there are two main flows that rhccc (in combination with subman, rhc, yggdrasil/rhcd, insights-client) supports:

1) A cloud system is started in a supported cloud provider with a cloud account that **is** associated with a particular organization known to RH (via cloud.redhat.com), with rhsmcertd.auto_registration set to 1, the system is automatically registered to the associated RH organization, `insights-client --register` is run automatically, and yggd/rhcd is automatically started.

2) A cloud system is started in a supported cloud provider with a cloud account that **is not** associated with a particular organization known to RH (via cloud.redhat.com), with rhsmcertd.auto_registration set to 1, the system is automatically registered to an anonymous organization. Nothing further happens automatically until and unless the consumer is migrated to a non-anonymous organization. Once that happens (with no further user interaction on the system): `insights-client --register` is run automatically, and yggd/rhcd is automatically started.


In keeping with the original nature of rhccc, upon system unregistration via subman (`subscription-manager unregister`): `insights-client --unregister --force` is run and yggd/rhcd are stopped.

Please note that without further changes neither use case 1 nor 2 above will retrigger `insights-client --register` if the automatic call to `insights-client --unregister --force` is unsuccessful. At this time it is unclear if this is anything more than an extremely unlikely edge-case.

The setup to try this out locally is a bit much so I've tried my best to make it easier for whoever looks at this PR and anyone who might need to make changes to this flow in the future with the following instructions.


# Steps to setup for testing this PR locally

## 1) Build and/or install yggdrasil & rhc & insights-client/insights-core

1.1) I recommend installing from the fedora repos yggdrasil and rhc (likely easiest and most reproducible): `sudo dnf install yggdrasil rhc`

1.2) insights-client/insights-core don't exist on fedora so got to install from source

1.3) Most of our projects can be built with one of the following:
     - `packit build locally`
     - `tito build --test --rpm -o /tmp/tito_build --no-cleanup`
       - (no-cleanup in case something goes weird and you'd like to see the artifacts of it)


## 2) Build and install subman off the 'csnyder/fix_owner_cache' branch

2.1) From a checkout of the subman repo run: `tito build --test --install --rpm -o /tmp/tito_build`  (this will install the resulting rpms)

2.2) Make sure the system is not registered (either unregister or clean): `sudo subscription-manager unregister` or `sudo subscription-manager clean`


## 3) Set up mock AWS IMDS, local candlepin in hosted mode

3.1) clone the internal repo with the bits necessary to run candlepin locally in a fake hosted mode to simulate registration to an anonymous org which can then be migrated to non-anon
  - `git clone git@INTERNAL_GIT:csnyder/cct-67.git`
  - (Ask csnyder if you need the actual value for INTERNAL_GIT)
  - `git checkout csnyder/cct_2110` (this is the branch that has the helper scripts referenced below

3.2) Run `bash ./start-aws-mock.sh` to start the mock AWS IMDS
  - Should see output indicating the mock aws-server is now running

3.3) Run `sudo bash ./patch-aws-cloud-what.sh`
  - This will modify the installed cloud_what python source (that was installed in step 2.1) to use the local mock AWS IMDS.
  
3.4) Run `sudo bash ./setup-sudo.sh`
  - This will modify the local rhsm conf to point to the soon-to-be-stood-up local candlepin
  - This will also install some fact overrides to make subman act as if the system is running on AWS (so it will attempt to reach out to the mock AWS IMDS and perform automatic registration)


## 4) Build and install the rhccc from this PR

4.1) From a checkout of this repo and on this PR branch run: `tito build --test --rpm -o /tmp/tito_build`

4.2) install /tmp/tito_build/noarch/redhat-cloud-client-configuration-redhat*.rpm
  - Please note, either test the rhccc*.rpm or the rhccc-cdn*.rpm. Not both at the same time as they conflict

4.3) Get systemd to start units as their configs specify (only need to do one of the following:

  - Reboot (if you want to see things are configured correctly without direct user intervention): `sudo systemctl reboot` **If you choose this option you'll need to do Step 3.2 above again)
  - Isolate default.target (this will start services etc to get to the specified target which should include what was just installed): `sudo systemctl isolate default.target`


At this point the system is ready to begin testing / verifying the most recently installed rhccc package. If a different rhccc package needs to be tested remove the current installed package and then follow Step 4 above again with the different branch etc.


# Verifying the functionality of the changes in this PR

## Two cases that should work with this PR

### Non-anonymous auto-registration

1. Run token-interactive.sh to completion (from cct-67 repo)
1. watch the logs of rhsmcertd to see what it does: `tail -f /var/log/rhsm/rhsmcertd.log`
1. In another terminal watch the logs of all the systemctl units from rhccc (the following should be all of them even including ones that won't be installed on all distros): `journalctl -f -u insights-register-pathexists.path -u insights-register.path -u insights-register.service -u insights-unregistered.path -u insights-unregistered.service -u insights-unregister.path -u insights-unregister.service -u rhccc-disable-rhui-repos.service -u rhcd-pathexists.path -u rhcd.path -u rhcd-stop.path -u rhcd-stop.service -u yggdrasil-pathexists.path -u yggdrasil.path -u yggdrasil-stop.path -u yggdrasil-stop.service -S "$(date --iso-8601=minutes)"`
1. In another terminal run `sudo rhsmcertd --now --debug --auto-registration`
1. Once the rhsmcertd log writes out: "(Auto-registration) performed successfully" note the time and look back to the journalctl terminal. You should see that (depending on distro) yggdrasil.service and insights-register.service were started. Please note that with the mock setup of things insights-register.service (which runs `insights-client --register`) is **not** expected to suceed, just to have been run.
1. You can also verify that the owner is not anonymous by running the following: `sudo jq '.["anonymous"]' /var/lib/rhsm/cache/current_owner.json`. This in the current implementation should output 'null' if the owner is not anonymous.

#### Unregistering after non-anonymous auto-registration
1. Run `sudo subscription-manager unregister` (or 'clean' if you don't have candlepin running anymore)

yggdrasil.service should be stopped. insights-unregister.service should have run (although he command it runs will fail as it wasn't successfully registered). Both can be checked using similar journalctl as above.

The intention was for the path watches to be unmasked and restarted after unregistration or clean but without further work if insights-unregister.service fails it's path watches are currently **not** reset.


### Anonymous auto-registration

1. Run token-interactive.sh until you see 'The system should be able to fully register now' **STOP in this terminal here for now** (from cct-67 repo)
1. In another terminal watch the logs of rhsmcertd to see what it does: `tail -f /var/log/rhsm/rhsmcertd.log`
1. In yet another terminal watch the logs of all the systemctl units from rhccc (the following should be all of them even including ones that won't be installed on all distros): `journalctl -f -u insights-register-pathexists.path -u insights-register.path -u insights-register.service -u insights-unregistered.path -u insights-unregistered.service -u insights-unregister.path -u insights-unregister.service -u rhccc-disable-rhui-repos.service -u rhcd-pathexists.path -u rhcd.path -u rhcd-stop.path -u rhcd-stop.service -u yggdrasil-pathexists.path -u yggdrasil.path -u yggdrasil-stop.path -u yggdrasil-stop.service -S "$(date --iso-8601=minutes)"`
1. In another terminal run `sudo rhsmcertd --now --debug --auto-registration`
1. Once the rhsmcertd log writes out: "(Auto-registration) performed successfully" note the time and look back to the journalctl terminal. You should see that (depending on distro) yggdrasil.service and insights-register.service were attempted to be started but **were not started** with a message like "insights-register.service: Skipped due to 'exec-condition'.".
1. Kill rhsmcertd and reset rhsmcertd (see section below)[#Restarting rhsmcertd if run from the terminal]
1. Verify that the owner **is anonymous** by running the following: `sudo jq '.["anonymous"]' /var/lib/rhsm/cache/current_owner.json`. This should return 'true'.

#### Phase two of the anonymous auto-registration
After the above section:
1. Go back to the terminal that is running token-interactive.sh and press enter one more time, wait for the migration to complete (script should exit)
1. In another terminal run rhsmcertd once more (this is just a faster way of making rhsmcertd check for new identity certs, you could just let it run in the background as a customer would): `sudo rhsmcertd --now --debug --auto-registration`
1. Once the rhsmcertd log writes out: "(Auto-registration) performed successfully" note the time and look back to the journalctl terminal. You should see that (depending on distro) yggdrasil.service and insights-register.service were attempted to be started and **were started**.
1. You can also verify that the owner is no longer anonymous by running the following: `sudo jq '.["anonymous"]' /var/lib/rhsm/cache/current_owner.json`. This in the current implementation should output 'null' if the owner is not anonymous.

If you run `subscription-manager unregister` or `subscription-manager clean` at this point the expectation would be the same as (described above)[#Unregistering after non-anonymous auto-registration].


## Restarting rhsmcertd if run from the terminal
Do the following to stop all rhsmcertd processes on the system and clear the filelock so rhsmcertd can be run from the cli again:
1. `sudo pkill rhsmcertd`
1. `sudo rm /var/lock/subsys/rhsmcertd >/dev/null 2>&1` (just in case)


# Thank you for reading all this! Hope this helps!
