### PR TITLE
fix: Require the correct minimum version of subscription-manager for anon registration

### DIFF
--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -51,7 +51,7 @@ Source100: LICENSE
 BuildArch:      noarch
 
 Requires:      insights-client
-Requires:      subscription-manager
+Requires:      subscription-manager >= 1.29.54
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 Requires:      rhc


### PR DESCRIPTION
This small change updates the specfile to require a minimum of the version of subscription-manager that has the owner cache invalidation fix. Given that there is nothing else specifically required for rhccc to do it's work with the anon registration flow from newer versions of subscription-manager (i.e. those that are or will be available in future RHEL) we don't need to require unique versions of subscription-manager per version of RHEL.


This PR is technically blocked on this version of subman being merged and released into centos-stream (at least for the change to be meaningful): https://gitlab.com/redhat/centos-stream/rpms/subscription-manager/-/merge_requests/83

Builds for rhccc for downstream release targets are unblocked after this PR.