### PR TITLE
fix: Require correct subman for RHEL 10 and RHEL 9

### DIFF
--- a/redhat-cloud-client-configuration.spec
+++ b/redhat-cloud-client-configuration.spec
@@ -51,7 +51,11 @@ Source100: LICENSE
 BuildArch:      noarch
 
 Requires:      insights-client
+%if 0%{?rhel} >= 10
+Requires:      subscription-manager >= 1.30.15
+%else
 Requires:      subscription-manager >= 1.29.54
+%endif
 
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 Requires:      rhc
@@ -69,7 +73,11 @@ Configure client autoregistration for cloud environments
 Summary: Red Hat cloud client configuration - CDN
 
 Requires:      insights-client
-Requires:      subscription-manager
+%if 0%{?rhel} >= 10
+Requires:      subscription-manager >= 1.30.15
+%else
+Requires:      subscription-manager >= 1.29.54
+%endif
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 Requires:      rhc
 %endif


### PR DESCRIPTION
This updates the subman requirement such that the right version is required for RHEL 10 vs RHEL 9. Please note that as implemented this will not require the "right" version of subman for RHEL 8 but that is b/c there is none for RHEL 8 that supports the recently added anon flow.

If we are to support the new anon flow on any other major version than RHEL 10 and RHEL 9, that will be follow on work in a separate PR.